### PR TITLE
chore: proper messaging for api key not added

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,9 +17,7 @@ export function activate(context: vscode.ExtensionContext) {
 	console.log('Congratulations, your extension "fluttergpt" is now active!');
     const config = vscode.workspace.getConfiguration('fluttergpt');
     const apiKey = config.get<string>('apiKey');
-    if(!apiKey){
-        return ;
-    }
+
     const openAIRepo = new OpenAIRepository(apiKey);
 
     let createWidgetDisposable = vscode.commands.registerCommand('fluttergpt.createWidget', async () => createWidgetFromDescription(openAIRepo));

--- a/src/repository/openai-repository.ts
+++ b/src/repository/openai-repository.ts
@@ -31,13 +31,17 @@ interface ChatCompletionResponse {
   }
 
 export class OpenAIRepository {
-    private apiKey: string;
+    private apiKey?: string;
   
-    constructor(apiKey: string) {
+    constructor(apiKey: string | undefined) {
       this.apiKey = apiKey;
     }
   
     public async getCompletion(prompt: { role: string, content: string }[]): Promise<string> {
+
+      if(!this.apiKey) {
+        throw new Error('API token not set, please go to extension settings to set it (read README.md for more info)');
+      }
     
       const request: ChatCompletionRequest = {
           model: 'gpt-3.5-turbo',


### PR DESCRIPTION
Currently in case keys are not added at the begging the activation methods eagerly returns and the error message raised at the time of command invocation doesn't point to root cause

<img width="333" alt="Screenshot 2023-04-16 at 10 34 59 PM" src="https://user-images.githubusercontent.com/21201278/232329568-99ac8d71-3aae-49ad-87bb-733d8e157970.png">

With this change we are raising a proper error message informing the user to add keys
<img width="578" alt="Screenshot 2023-04-16 at 10 47 12 PM" src="https://user-images.githubusercontent.com/21201278/232329604-070583fe-cec3-4f8f-9bd0-9e8f827a14d2.png">

