### PR TITLE
correct path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "widgets"
   ],
   "activationEvents": [],
-  "main": "./out/extension.js",
+  "main": "./src/extension.ts",
   "contributes": {
     "configuration": {
       "title": "FlutterGPT",


### PR DESCRIPTION
Was checking issue #15, and it seems to be the case that vs code can not detect the extension as the path to extension.ts in package.json is incorrect